### PR TITLE
[MkFitCore] Backward fit using prop-to-plane, reordering of PS modules so P comes first.

### DIFF
--- a/RecoTracker/MkFitCMS/interface/LayerNumberConverter.h
+++ b/RecoTracker/MkFitCMS/interface/LayerNumberConverter.h
@@ -25,14 +25,16 @@ namespace mkfit {
     bool isPhase2() const { return lo_ == TkLayout::phase2; }
     int convertLayerNumber(int det, int lay, bool useMatched, int isStereo, bool posZ) const {
       if (lo_ == TkLayout::phase2) {
+        // For TOB / TEC stereo is used for P in PS modules so we move stereo before the other
+        // one. The same is done for 2S layers (well, TEC is mixed PS / 2S anyway).
         if (det == 1)
           return lay - 1;
         if (det == 2)
           return 16 + lay - 1 + (posZ ? 0 : 22);
         if (det == 5)
-          return 4 + (2 * (lay - 1)) + isStereo;
+          return 4 + (2 * (lay - 1)) + 1 - isStereo;
         if (det == 4)
-          return 16 + 12 + (2 * (lay - 1)) + isStereo + (posZ ? 0 : 22);
+          return 16 + 12 + (2 * (lay - 1)) + 1 - isStereo + (posZ ? 0 : 22);
         throw std::runtime_error("bad subDet");
       }
 

--- a/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
+++ b/RecoTracker/MkFitCore/src/KalmanUtilsMPlex.h
@@ -10,6 +10,15 @@ namespace mkfit {
 
   enum KalmanFilterOperation { KFO_Calculate_Chi2 = 1, KFO_Update_Params = 2, KFO_Local_Cov = 4 };
 
+  inline void kalmanCheckChargeFlip(MPlexLV& outPar, MPlexQI& Chg, int N_proc) {
+    for (int n = 0; n < NN; ++n) {
+      if (n < N_proc && outPar.At(n, 3, 0) < 0) {
+        Chg.At(n, 0, 0) = -Chg.At(n, 0, 0);
+        outPar.At(n, 3, 0) = -outPar.At(n, 3, 0);
+      }
+    }
+  }
+
   //------------------------------------------------------------------------------
 
   void kalmanUpdate(const MPlexLS& psErr,

--- a/RecoTracker/MkFitCore/src/MkBuilder.cc
+++ b/RecoTracker/MkFitCore/src/MkBuilder.cc
@@ -1381,18 +1381,31 @@ namespace mkfit {
       }
 #endif
 
-      // input tracks
-      mkfndr->bkFitInputTracks(eoccs, icand, end);
+      if (Config::usePropToPlane) {
+        // input tracks
+        mkfndr->bkFitInputTracks(eoccs, icand, end);
+        // fit tracks back to first layer
+        mkfndr->bkFitFitTracksProp2Plane(m_job->m_event_of_hits, st_par, end - icand, chi_debug);
+        // tracks are put back into correcponding TrackCand when finsihed in the above function
+        // now move one last time to PCA
+        if (prop_config.backward_fit_to_pca) {
+          mkfndr->bkFitInputTracks(eoccs, icand, end);
+          mkfndr->bkFitPropTracksToPCA(end - icand);
+          mkfndr->bkFitOutputTracks(eoccs, icand, end, prop_config.backward_fit_to_pca);
+        }
+      } else {
+        // input tracks
+        mkfndr->bkFitInputTracks(eoccs, icand, end);
+        // fit tracks back to first layer
+        mkfndr->bkFitFitTracks(m_job->m_event_of_hits, st_par, end - icand, chi_debug);
 
-      // fit tracks back to first layer
-      mkfndr->bkFitFitTracks(m_job->m_event_of_hits, st_par, end - icand, chi_debug);
+        // now move one last time to PCA
+        if (prop_config.backward_fit_to_pca) {
+          mkfndr->bkFitPropTracksToPCA(end - icand);
+        }
 
-      // now move one last time to PCA
-      if (prop_config.backward_fit_to_pca) {
-        mkfndr->bkFitPropTracksToPCA(end - icand);
+        mkfndr->bkFitOutputTracks(eoccs, icand, end, prop_config.backward_fit_to_pca);
       }
-
-      mkfndr->bkFitOutputTracks(eoccs, icand, end, prop_config.backward_fit_to_pca);
 
 #ifdef DEBUG_FINAL_FIT
       dprintf("Post Final fit for %d - %d\n", icand, end);

--- a/RecoTracker/MkFitCore/src/MkFinder.h
+++ b/RecoTracker/MkFitCore/src/MkFinder.h
@@ -171,6 +171,11 @@ namespace mkfit {
                         const int N_proc,
                         bool chiDebug = false);
 
+    void bkFitFitTracksProp2Plane(const EventOfHits &eventofhits,
+                                  const SteeringParams &st_par,
+                                  const int N_proc,
+                                  bool chiDebug = false);
+
     void bkFitPropTracksToPCA(const int N_proc);
 
     //----------------------------------------------------------------------------


### PR DESCRIPTION
The json should be:
http://xrd-cache-1.t2.ucsd.edu/matevz/PKF/mkfit-phase2-initialStep.json
or
~matevz/mkfit-phase2-initialStep.json

I had some trouble extracting this code, let me know if anything looks funky before spending too much time on it.